### PR TITLE
Downgrade Protobuf from 4.x to 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "com.google.protobuf:protoc"
+        versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
   - package-ecosystem: "maven"
     directory: "/java/maven"
     commit-message:
@@ -14,6 +17,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "com.google.protobuf:protoc"
+        versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
   - package-ecosystem: "gradle"
     directory: "/kotlin/gradle"
     commit-message:
@@ -25,6 +31,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "com.google.protobuf:protoc"
+        versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
   - package-ecosystem: "maven"
     directory: "/kotlin/maven"
     commit-message:
@@ -32,6 +41,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "com.google.protobuf:protoc"
+        versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
   - package-ecosystem: "gradle"
     directory: "/server"
     commit-message:
@@ -43,3 +55,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    ignore:
+      - dependency-name: "com.google.protobuf:protoc"
+        versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015

--- a/java/gradle/build.gradle
+++ b/java/gradle/build.gradle
@@ -43,7 +43,7 @@ sourceSets {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:4.26.0"
+    artifact = "com.google.protobuf:protoc:3.25.3"
   }
   plugins {
     grpc {

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -19,7 +19,7 @@
         <gatling-maven-plugin.version>4.8.2</gatling-maven-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-        <protobuf.version>3.24.2</protobuf.version>
+        <protobuf.version>3.25.3</protobuf.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <protoc-gen-grpc-java.version>1.57.2</protoc-gen-grpc-java.version>
         <spotless.version>2.43.0</spotless.version>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -8,10 +8,7 @@
     <version>3.10.5</version>
 
     <properties>
-        <!-- use the following if you're compiling with JDK 8-->
-        <!--<maven.compiler.source>1.8</maven.compiler.source>-->
-        <!--<maven.compiler.target>1.8</maven.compiler.target>-->
-        <!-- comment the 2 lines above and uncomment the line bellow if you're compiling with JDK 11 or 17 -->
+        <!-- Change the line bellow if you're compiling with JDK 11 or 21 -->
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gatling.version>${project.version}</gatling.version>

--- a/kotlin/maven/pom.xml
+++ b/kotlin/maven/pom.xml
@@ -8,10 +8,7 @@
     <version>3.10.5</version>
 
     <properties>
-        <!-- use the following if you're compiling with JDK 8-->
-        <!--<maven.compiler.source>1.8</maven.compiler.source>-->
-        <!--<maven.compiler.target>1.8</maven.compiler.target>-->
-        <!-- comment the 2 lines above and uncomment the line bellow if you're compiling with JDK 11 or 17 -->
+        <!-- Change the line bellow if you're compiling with JDK 11 or 21 -->
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gatling.version>${project.version}</gatling.version>

--- a/kotlin/maven/pom.xml
+++ b/kotlin/maven/pom.xml
@@ -21,7 +21,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <protobuf.version>4.26.0</protobuf.version>
+        <protobuf.version>3.25.3</protobuf.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <protoc-gen-grpc-java.version>1.57.2</protoc-gen-grpc-java.version>
         <spotless.version>2.43.0</spotless.version>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,7 +27,7 @@ idea {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:4.26.0"
+    artifact = "com.google.protobuf:protoc:3.25.3"
   }
   plugins {
     grpc {


### PR DESCRIPTION
grpc-java is not currently fully compatible with Protobuf 4; see: https://github.com/grpc/grpc-java/issues/11015

In particular, protobuf 4 breaks our demo server due to an incompatibility between the generated code and what the grpc-java library expects.