### PR TITLE
fix: Add protobuf-kotlin to dependabot ignore lists for version 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
     ignore:
       - dependency-name: "com.google.protobuf:protoc"
         versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
+      - dependency-name: "com.google.protobuf:protobuf-kotlin"
+        versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
   - package-ecosystem: "maven"
     directory: "/kotlin/maven"
     commit-message:
@@ -43,6 +45,8 @@ updates:
       day: "sunday"
     ignore:
       - dependency-name: "com.google.protobuf:protoc"
+        versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
+      - dependency-name: "com.google.protobuf:protobuf-kotlin"
         versions: ['>= 4'] # https://github.com/grpc/grpc-java/issues/11015
   - package-ecosystem: "gradle"
     directory: "/server"


### PR DESCRIPTION
gRPC Java is stuck on Protobuf 3.x for now. The Protobuf Kotlin library should also stay on 3.x.